### PR TITLE
Remove unnecessary evaluations of <Show> and <Match> conditions

### DIFF
--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -106,16 +106,23 @@ export function Show<T>(props: {
   children: JSX.Element | ((item: NonNullable<T> | Accessor<NonNullable<T>>) => JSX.Element);
 }): JSX.Element {
   const keyed = props.keyed;
-  const condition = createMemo<T | undefined | null | boolean>(
+  const conditionValue = createMemo<T | undefined | null | boolean>(
     () => props.when,
     undefined,
-    IS_DEV
-      ? {
-          equals: (a, b) => (keyed ? a === b : !a === !b),
-          name: "condition"
-        }
-      : { equals: (a, b) => (keyed ? a === b : !a === !b) }
+    IS_DEV ? { name: "condition value" } : undefined
   );
+  const condition = keyed
+    ? conditionValue
+    : createMemo(
+        conditionValue,
+        undefined,
+        IS_DEV
+          ? {
+              equals: (a, b) => !a === !b,
+              name: "condition"
+            }
+          : { equals: (a, b) => !a === !b }
+      );
   return createMemo(
     () => {
       const c = condition();
@@ -129,7 +136,7 @@ export function Show<T>(props: {
                   ? (c as T)
                   : () => {
                       if (!untrack(condition)) throw narrowedError("Show");
-                      return props.when;
+                      return conditionValue();
                     }
               )
             )

--- a/packages/solid/src/render/flow.ts
+++ b/packages/solid/src/render/flow.ts
@@ -7,7 +7,6 @@ import {
   Accessor,
   Setter,
   onCleanup,
-  MemoOptions,
   IS_DEV
 } from "../reactive/signal.js";
 import { mapArray, indexArray } from "../reactive/array.js";
@@ -149,7 +148,7 @@ export function Show<T>(props: {
   ) as unknown as JSX.Element;
 }
 
-type EvalConditions = readonly [number, unknown?, MatchProps<unknown>?];
+type EvalConditions = readonly [number, Accessor<unknown>, MatchProps<unknown>];
 
 /**
  * Switches between content based on mutually exclusive conditions
@@ -166,47 +165,58 @@ type EvalConditions = readonly [number, unknown?, MatchProps<unknown>?];
  * @description https://docs.solidjs.com/reference/components/switch-and-match
  */
 export function Switch(props: { fallback?: JSX.Element; children: JSX.Element }): JSX.Element {
-  let keyed = false;
-  const equals: MemoOptions<EvalConditions>["equals"] = (a, b) =>
-    (keyed ? a[1] === b[1] : !a[1] === !b[1]) && a[2] === b[2];
-  const conditions = children(() => props.children) as unknown as () => MatchProps<unknown>[],
-    evalConditions = createMemo(
-      (): EvalConditions => {
-        let conds = conditions();
-        if (!Array.isArray(conds)) conds = [conds];
-        for (let i = 0; i < conds.length; i++) {
-          const c = conds[i].when;
-          if (c) {
-            keyed = !!conds[i].keyed;
-            return [i, c, conds[i]];
-          }
-        }
-        return [-1];
-      },
-      undefined,
-      IS_DEV ? { equals, name: "eval conditions" } : { equals }
-    );
+  const chs = children(() => props.children);
+  const switchFunc = createMemo(() => {
+    const ch = chs() as unknown as MatchProps<unknown> | MatchProps<unknown>[];
+    const mps = Array.isArray(ch) ? ch : [ch];
+    let func: Accessor<EvalConditions | undefined> = () => undefined;
+    for (let i = 0; i < mps.length; i++) {
+      const index = i;
+      const mp = mps[i];
+      const prevFunc = func;
+      const conditionValue = createMemo(
+        () => (prevFunc() ? undefined : mp.when),
+        undefined,
+        IS_DEV ? { name: "condition value" } : undefined
+      );
+      const condition = mp.keyed
+        ? conditionValue
+        : createMemo(
+            conditionValue,
+            undefined,
+            IS_DEV
+              ? {
+                  equals: (a, b) => !a === !b,
+                  name: "condition"
+                }
+              : { equals: (a, b) => !a === !b }
+          );
+      func = () => prevFunc() || (condition() ? [index, conditionValue, mp] : undefined);
+    }
+    return func;
+  });
   return createMemo(
     () => {
-      const [index, when, cond] = evalConditions();
-      if (index < 0) return props.fallback;
-      const c = cond!.children;
-      const fn = typeof c === "function" && c.length > 0;
+      const sel = switchFunc()();
+      if (!sel) return props.fallback;
+      const [index, conditionValue, mp] = sel;
+      const child = mp.children;
+      const fn = typeof child === "function" && child.length > 0;
       return fn
         ? untrack(() =>
-            (c as any)(
-              keyed
-                ? when
+            (child as any)(
+              mp.keyed
+                ? (conditionValue() as any)
                 : () => {
-                    if (untrack(evalConditions)[0] !== index) throw narrowedError("Match");
-                    return cond!.when;
+                    if (untrack(switchFunc)()?.[0] !== index) throw narrowedError("Match");
+                    return conditionValue();
                   }
             )
           )
-        : c;
+        : child;
     },
     undefined,
-    IS_DEV ? { name: "value" } : undefined
+    IS_DEV ? { name: "eval conditions" } : undefined
   ) as unknown as JSX.Element;
 }
 

--- a/packages/solid/web/test/show.spec.tsx
+++ b/packages/solid/web/test/show.spec.tsx
@@ -72,12 +72,17 @@ describe("Testing an only child show control flow with DOM children", () => {
 describe("Testing nonkeyed show control flow", () => {
   let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
-  let executed = 0;
+  let whenExecuted = 0;
+  let childrenExecuted = 0;
+  function when() {
+    whenExecuted++;
+    return count();
+  }
   const Component = () => (
     <div ref={div}>
-      <Show when={count()}>
+      <Show when={when()}>
         <span>{count()}</span>
-        <span>{executed++}</span>
+        <span>{childrenExecuted++}</span>
       </Show>
     </div>
   );
@@ -89,19 +94,27 @@ describe("Testing nonkeyed show control flow", () => {
     });
 
     expect(div.innerHTML).toBe("");
-    expect(executed).toBe(0);
+    expect(whenExecuted).toBe(1);
+    expect(childrenExecuted).toBe(0);
   });
 
   test("Toggle show control flow", () => {
     setCount(7);
+    expect(whenExecuted).toBe(2);
     expect((div.firstChild as HTMLSpanElement).innerHTML).toBe("7");
-    expect(executed).toBe(1);
+    expect(childrenExecuted).toBe(1);
     setCount(5);
+    expect(whenExecuted).toBe(3);
     expect((div.firstChild as HTMLSpanElement).innerHTML).toBe("5");
-    expect(executed).toBe(1);
+    expect(childrenExecuted).toBe(1);
+    setCount(5);
+    expect(whenExecuted).toBe(3);
     setCount(0);
+    expect(whenExecuted).toBe(4);
     expect(div.innerHTML).toBe("");
-    expect(executed).toBe(1);
+    expect(childrenExecuted).toBe(1);
+    setCount(5);
+    expect(whenExecuted).toBe(5);
   });
 
   test("dispose", () => disposer());
@@ -110,12 +123,17 @@ describe("Testing nonkeyed show control flow", () => {
 describe("Testing keyed show control flow", () => {
   let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
-  let executed = 0;
+  let whenExecuted = 0;
+  let childrenExecuted = 0;
+  function when() {
+    whenExecuted++;
+    return count();
+  }
   const Component = () => (
     <div ref={div}>
-      <Show when={count()} keyed>
+      <Show when={when()} keyed>
         <span>{count()}</span>
-        <span>{executed++}</span>
+        <span>{childrenExecuted++}</span>
       </Show>
     </div>
   );
@@ -127,19 +145,27 @@ describe("Testing keyed show control flow", () => {
     });
 
     expect(div.innerHTML).toBe("");
-    expect(executed).toBe(0);
+    expect(whenExecuted).toBe(1);
+    expect(childrenExecuted).toBe(0);
   });
 
   test("Toggle show control flow", () => {
     setCount(7);
+    expect(whenExecuted).toBe(2);
     expect((div.firstChild as HTMLSpanElement).innerHTML).toBe("7");
-    expect(executed).toBe(1);
+    expect(childrenExecuted).toBe(1);
     setCount(5);
+    expect(whenExecuted).toBe(3);
     expect((div.firstChild as HTMLSpanElement).innerHTML).toBe("5");
-    expect(executed).toBe(2);
+    expect(childrenExecuted).toBe(2);
+    setCount(5);
+    expect(whenExecuted).toBe(3);
     setCount(0);
+    expect(whenExecuted).toBe(4);
     expect(div.innerHTML).toBe("");
-    expect(executed).toBe(2);
+    expect(childrenExecuted).toBe(2);
+    setCount(5);
+    expect(whenExecuted).toBe(5);
   });
 
   test("dispose", () => disposer());
@@ -148,14 +174,19 @@ describe("Testing keyed show control flow", () => {
 describe("Testing nonkeyed function show control flow", () => {
   let div!: HTMLDivElement, disposer: () => void;
   const [count, setCount] = createSignal(0);
-  let executed = 0;
+  let whenExecuted = 0;
+  let childrenExecuted = 0;
+  function when() {
+    whenExecuted++;
+    return count();
+  }
   const Component = () => (
     <div ref={div}>
-      <Show when={count()}>
+      <Show when={when()}>
         {count => (
           <>
             <span>{count()}</span>
-            <span>{executed++}</span>
+            <span>{childrenExecuted++}</span>
           </>
         )}
       </Show>
@@ -169,19 +200,27 @@ describe("Testing nonkeyed function show control flow", () => {
     });
 
     expect(div.innerHTML).toBe("");
-    expect(executed).toBe(0);
+    expect(whenExecuted).toBe(1);
+    expect(childrenExecuted).toBe(0);
   });
 
   test("Toggle show control flow", () => {
     setCount(7);
+    expect(whenExecuted).toBe(2);
     expect((div.firstChild as HTMLSpanElement).innerHTML).toBe("7");
-    expect(executed).toBe(1);
+    expect(childrenExecuted).toBe(1);
     setCount(5);
+    expect(whenExecuted).toBe(3);
     expect((div.firstChild as HTMLSpanElement).innerHTML).toBe("5");
-    expect(executed).toBe(1);
+    expect(childrenExecuted).toBe(1);
+    setCount(5);
+    expect(whenExecuted).toBe(3);
     setCount(0);
+    expect(whenExecuted).toBe(4);
     expect(div.innerHTML).toBe("");
-    expect(executed).toBe(1);
+    expect(childrenExecuted).toBe(1);
+    setCount(5);
+    expect(whenExecuted).toBe(5);
   });
 
   test("dispose", () => disposer());


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/solidjs/solid) and create your branch from `main`.
  2. Run `pnpm i` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. You should run `pnpm build` before running any tests as it copies some files in that are required for Solid to work.
  5. Ensure the test suite passes (`pnpm test`).
  6. Format your code with [prettier](https://github.com/prettier/prettier).
  7. Commit with conventional commits standards
-->

## Summary

This change removes unnecessary evaluations of the `when` conditions in the `<Show>` and `<Match>` components. Both these components used to evaluate the condition twice immediately after creation if the condition was true, children was specified as a function and keyed was not specified.

This was especially problematic when the condition produced JSX.Element which was then displayed by the children function, as two copies of the elements were instantiated.

This change also removes unnecessary evaluations of `<Match>` conditions in a sutiation where the condition did not change, but only a later `<Match>`'s condition changed.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Added unit tests demonstrating the described problems, and made `pnpm test` pass.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
-->

fixes #2406